### PR TITLE
fix(document-classifier): load each fasttext model once, serialise access

### DIFF
--- a/packages/document-classifier/src/main/kotlin/org/migor/feedless/classifier/FastTextDocumentClassifier.kt
+++ b/packages/document-classifier/src/main/kotlin/org/migor/feedless/classifier/FastTextDocumentClassifier.kt
@@ -6,17 +6,45 @@ import org.migor.feedless.document.DocumentClass
 import org.migor.feedless.document.DocumentClassifier
 import org.migor.feedless.document.DocumentClassifierModel
 import org.slf4j.LoggerFactory
+import kotlin.math.exp
 
+private const val MAX_PREDICTIONS = 3
+private const val FASTTEXT_LABEL_PREFIX = "__label__"
 
-class FastTextDocumentClassifier : DocumentClassifier {
+private fun loadFastText(path: String): JFastText {
+  val ft = JFastText()
+  ft.loadModel(path)
+  return ft
+}
+
+class FastTextDocumentClassifier(
+  loader: (String) -> JFastText = ::loadFastText,
+) : DocumentClassifier {
 
   private val log = LoggerFactory.getLogger(FastTextDocumentClassifier::class.java)
 
-  override suspend fun classify(document: Document, model: DocumentClassifierModel): List<DocumentClass> {
-    val ft = JFastText()
-    ft.loadModel(model.model)
+  private val models = ModelCache { path ->
+    log.info("loading fasttext model $path")
+    loader(path)
+  }
 
+  override suspend fun classify(
+    document: Document,
+    model: DocumentClassifierModel,
+  ): List<DocumentClass> {
     val text = "${document.title} ${document.text}"
-    return ft.predictProba(text, 3).map { DocumentClass(it.label, it.logProb.toDouble()) }
+    return models.withModel(model.model) { ft ->
+      ft.predictProba(text, MAX_PREDICTIONS).map {
+        DocumentClass(
+          // fastText gibt das Label in seinem Ablageformat zurück, also mit
+          // dem Präfix "__label__". Das ist ein Detail des Dateiformats und
+          // gehört nicht in die Domäne.
+          it.label.removePrefix(FASTTEXT_LABEL_PREFIX),
+          // predictProba liefert eine Log-Wahrscheinlichkeit, also einen Wert
+          // <= 0. DocumentClass.probability erwartet eine Wahrscheinlichkeit.
+          exp(it.logProb.toDouble()),
+        )
+      }
+    }
   }
 }

--- a/packages/document-classifier/src/main/kotlin/org/migor/feedless/classifier/ModelCache.kt
+++ b/packages/document-classifier/src/main/kotlin/org/migor/feedless/classifier/ModelCache.kt
@@ -1,0 +1,41 @@
+package org.migor.feedless.classifier
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Hält je Modellpfad genau eine geladene Instanz und serialisiert den Zugriff
+ * darauf.
+ *
+ * Beides ist nötig. Das Laden ist teuer und lief bisher bei jedem einzelnen
+ * Klassifizierungsaufruf. Und die geladene Instanz darf nicht nebenläufig
+ * benutzt werden: JFastText hält einen nativen Zeiger, und fastText verwendet
+ * beim Vorhersagen veränderliche Member-Vektoren im Modell. Threadsicherheit
+ * ist dort weder dokumentiert noch von aussen belegbar, also wird sie hier
+ * nicht vorausgesetzt.
+ *
+ * Der Preis ist ein Vorhersagevorgang zur Zeit je Modell. Bei einer Vorhersage
+ * im Mikrosekundenbereich ist das gegenüber dem bisherigen Laden pro Aufruf
+ * ein Gewinn, kein Verlust.
+ */
+class ModelCache<T>(private val load: (String) -> T) {
+
+  private class Entry<T>(val model: T) {
+    val mutex = Mutex()
+  }
+
+  private val entries = ConcurrentHashMap<String, Entry<T>>()
+
+  /**
+   * Führt [block] mit dem Modell zu [path] aus. Das Modell wird beim ersten
+   * Zugriff geladen, danach wiederverwendet.
+   */
+  suspend fun <R> withModel(path: String, block: (T) -> R): R {
+    val entry = entries.computeIfAbsent(path) { Entry(load(it)) }
+    return entry.mutex.withLock { block(entry.model) }
+  }
+
+  /** Anzahl geladener Modelle. Für Tests und Diagnose. */
+  fun size(): Int = entries.size
+}

--- a/packages/document-classifier/src/test/kotlin/org/migor/feedless/classifier/FastTextDocumentClassifierTest.kt
+++ b/packages/document-classifier/src/test/kotlin/org/migor/feedless/classifier/FastTextDocumentClassifierTest.kt
@@ -1,40 +1,140 @@
 package org.migor.feedless.classifier
 
+import com.github.jfasttext.JFastText
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import org.migor.feedless.document.Document
 import org.migor.feedless.document.DocumentClassifierModel
 import org.migor.feedless.document.ReleaseStatus
 import org.migor.feedless.repository.RepositoryId
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.*
+import java.util.concurrent.atomic.AtomicInteger
 
 class FastTextDocumentClassifierTest {
 
-  private lateinit var classifier: FastTextDocumentClassifier
+  companion object {
+    @TempDir
+    @JvmStatic
+    lateinit var tempDir: Path
 
-  @BeforeEach
-  fun setUp() {
-    classifier = FastTextDocumentClassifier()
+    private lateinit var modelPath: String
+
+    /**
+     * Baut ein winziges echtes Modell, statt einen Pfad zu erfinden. Der
+     * frühere Test übergab "test" und scheiterte an "Model file doesn't
+     * exist!" - er hat nie etwas klassifiziert.
+     */
+    @BeforeAll
+    @JvmStatic
+    fun trainModel() {
+      val trainingData = tempDir.resolve("train.txt")
+      Files.write(
+        trainingData,
+        listOf(
+          "__label__sport Fussballturnier auf dem Sportplatz mit mehreren Mannschaften",
+          "__label__sport Volleyball Training in der Turnhalle fuer alle Altersgruppen",
+          "__label__sport Laufgruppe trifft sich zum gemeinsamen Joggen im Wald",
+          "__label__sport Schwimmkurs im Hallenbad mit erfahrenen Trainern",
+          "__label__musik Konzert des Musikvereins in der Kirche mit Blasmusik",
+          "__label__musik Chorabend mit Liedern aus verschiedenen Jahrhunderten",
+          "__label__musik Jazzabend im Kulturkeller mit einer lokalen Band",
+          "__label__musik Platzkonzert der Harmonie auf dem Dorfplatz",
+        ),
+      )
+      val modelBase = tempDir.resolve("model").toString()
+      JFastText().runCmd(
+        arrayOf(
+          "supervised",
+          "-input", trainingData.toString(),
+          "-output", modelBase,
+          "-epoch", "50",
+          "-dim", "10",
+          "-minCount", "1",
+        ),
+      )
+      modelPath = "$modelBase.bin"
+    }
   }
+
+  private fun documentWith(title: String, text: String) = Document(
+    url = "https://example.com/event",
+    title = title,
+    text = text,
+    repositoryId = RepositoryId(),
+    status = ReleaseStatus.released,
+    contentHash = UUID.randomUUID().toString(),
+  )
 
   @Test
   fun `should classify document`() = runTest {
-    val document = Document(
-      url = "https://example.com/article",
-      title = "New MacBook Pro Review",
-      text = "The new MacBook Pro has incredible performance and battery life. The M3 chip delivers amazing speed.",
-      repositoryId = RepositoryId(),
-      status = ReleaseStatus.released,
-      contentHash = UUID.randomUUID().toString()
+    val classifier = FastTextDocumentClassifier()
+
+    val results = classifier.classify(
+      documentWith("Fussballturnier", "Turnier auf dem Sportplatz mit Mannschaften"),
+      DocumentClassifierModel(modelPath),
     )
 
-    val results = classifier.classify(document, DocumentClassifierModel("test"))
-
     assertThat(results).isNotEmpty()
-    assertThat(results.first().category).isNotEmpty()
-    assertThat(results.first().probability).isBetween(0.0, 1.0)
+    assertThat(results.first().category).isEqualTo("sport")
   }
 
+  /**
+   * fastText gibt Labels in seinem Ablageformat zurück, also als
+   * "__label__sport". Das ist ein Detail des Dateiformats und hat in der
+   * Domäne nichts zu suchen.
+   */
+  @Test
+  fun `strips the fasttext label prefix`() = runTest {
+    val classifier = FastTextDocumentClassifier()
+
+    val results = classifier.classify(
+      documentWith("Fussballturnier", "Turnier auf dem Sportplatz"),
+      DocumentClassifierModel(modelPath),
+    )
+
+    assertThat(results).isNotEmpty()
+    assertThat(results).noneMatch { it.category.startsWith("__label__") }
+    assertThat(results.map { it.category }).containsAnyOf("sport", "musik")
+  }
+
+  /**
+   * predictProba liefert eine Log-Wahrscheinlichkeit, also einen Wert <= 0.
+   * Der wurde bisher ungewandelt in DocumentClass.probability geschrieben.
+   */
+  @Test
+  fun `reports a probability, not a log probability`() = runTest {
+    val classifier = FastTextDocumentClassifier()
+
+    val results = classifier.classify(
+      documentWith("Konzert", "Konzert des Musikvereins in der Kirche"),
+      DocumentClassifierModel(modelPath),
+    )
+
+    assertThat(results).allSatisfy {
+      assertThat(it.probability).isBetween(0.0, 1.0)
+    }
+  }
+
+  @Test
+  fun `loads the model once across many classifications`() = runTest {
+    val loads = AtomicInteger()
+    val classifier = FastTextDocumentClassifier { path ->
+      loads.incrementAndGet()
+      JFastText().apply { loadModel(path) }
+    }
+
+    repeat(5) {
+      classifier.classify(
+        documentWith("Konzert", "Konzert des Musikvereins"),
+        DocumentClassifierModel(modelPath),
+      )
+    }
+
+    assertThat(loads.get()).isEqualTo(1)
+  }
 }

--- a/packages/document-classifier/src/test/kotlin/org/migor/feedless/classifier/ModelCacheTest.kt
+++ b/packages/document-classifier/src/test/kotlin/org/migor/feedless/classifier/ModelCacheTest.kt
@@ -1,0 +1,124 @@
+package org.migor.feedless.classifier
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Der Klassifikator lud das Modell bisher bei jedem einzelnen Aufruf von der
+ * Platte. Diese Tests halten die beiden Eigenschaften fest, die das ersetzt:
+ * einmal laden je Pfad, und nie nebenläufig auf derselben Instanz arbeiten.
+ */
+class ModelCacheTest {
+
+  @Test
+  fun `loads a model once and reuses it`() = runTest {
+    val loads = AtomicInteger()
+    val cache = ModelCache { path -> "$path:${loads.incrementAndGet()}" }
+
+    val first = cache.withModel("model-a") { it }
+    val second = cache.withModel("model-a") { it }
+
+    assertThat(loads.get()).isEqualTo(1)
+    assertThat(first).isEqualTo(second)
+    assertThat(cache.size()).isEqualTo(1)
+  }
+
+  @Test
+  fun `keeps one instance per model path`() = runTest {
+    val loads = AtomicInteger()
+    val cache = ModelCache { path -> "$path:${loads.incrementAndGet()}" }
+
+    cache.withModel("model-a") { it }
+    cache.withModel("model-b") { it }
+    cache.withModel("model-a") { it }
+
+    assertThat(loads.get()).isEqualTo(2)
+    assertThat(cache.size()).isEqualTo(2)
+  }
+
+  @Test
+  fun `loads a model once even under concurrent first access`() = runTest {
+    val loads = AtomicInteger()
+    val cache = ModelCache { path -> "$path:${loads.incrementAndGet()}" }
+
+    withContext(Dispatchers.Default) {
+      (1..32).map { async { cache.withModel("model-a") { it } } }.awaitAll()
+    }
+
+    assertThat(loads.get()).isEqualTo(1)
+  }
+
+  /**
+   * Der eigentliche Zweck: JFastText hält einen nativen Zeiger, und fastText
+   * arbeitet beim Vorhersagen auf veränderlichen Member-Vektoren. Zwei
+   * gleichzeitige Vorhersagen auf derselben Instanz wären ein Datenrennen.
+   */
+  @Test
+  fun `never runs two blocks on the same model at once`() = runTest {
+    val cache = ModelCache { it }
+    val inFlight = AtomicInteger()
+    val maxInFlight = AtomicInteger()
+
+    withContext(Dispatchers.Default) {
+      (1..16).map {
+        async {
+          cache.withModel("model-a") {
+            val now = inFlight.incrementAndGet()
+            maxInFlight.updateAndGet { max -> maxOf(max, now) }
+            Thread.sleep(2)
+            inFlight.decrementAndGet()
+          }
+        }
+      }.awaitAll()
+    }
+
+    assertThat(maxInFlight.get()).isEqualTo(1)
+  }
+
+  @Test
+  fun `lets different models run at the same time`() = runTest {
+    val cache = ModelCache { it }
+    val started = AtomicInteger()
+
+    withContext(Dispatchers.Default) {
+      listOf("model-a", "model-b").map { path ->
+        async {
+          cache.withModel(path) {
+            started.incrementAndGet()
+            // Wartet, bis der andere Pfad ebenfalls gestartet ist. Bei einer
+            // globalen Sperre statt einer je Modell liefe das in den Timeout.
+            while (started.get() < 2) {
+              Thread.sleep(1)
+            }
+          }
+        }
+      }.awaitAll()
+    }
+
+    assertThat(started.get()).isEqualTo(2)
+  }
+
+  @Test
+  fun `propagates a failure to load and does not cache it`() = runTest {
+    val attempts = AtomicInteger()
+    val cache = ModelCache<String> {
+      attempts.incrementAndGet()
+      throw IllegalArgumentException("Model file doesn't exist!")
+    }
+
+    repeat(2) {
+      runCatching { cache.withModel("missing") { it } }
+    }
+
+    assertThat(attempts.get()).isEqualTo(2)
+    assertThat(cache.size()).isEqualTo(0)
+    delay(0)
+  }
+}


### PR DESCRIPTION
`classify()` erzeugte bei **jedem einzelnen Aufruf** ein neues `JFastText` und las das Modell von der Platte.

## Was sich ändert

`ModelCache` hält je Modellpfad genau eine geladene Instanz und serialisiert den Zugriff darauf.

**Warum serialisiert und nicht geteilt:** `JFastText` hält einen einzelnen nativen Zeiger (`FastTextWrapper$FastTextApi fta`), und fastText arbeitet beim Vorhersagen auf veränderlichen Member-Vektoren im Modell. Dass `predictProba` nebenläufig sicher ist, ist weder dokumentiert noch von aussen belegbar — also wird es nicht vorausgesetzt. Die Sperre gilt **pro Modell**, verschiedene Modelle laufen weiterhin parallel.

Der Preis ist eine Vorhersage zur Zeit je Modell, im Mikrosekundenbereich. Gegen einen Plattenzugriff pro Aufruf ist das ein Gewinn.

## Zwei Fehler, die der Test offengelegt hat

Der bestehende Test war **rot**: er übergab den Modellpfad `"test"` und starb an `Model file doesn't exist!`. Er hat nie etwas klassifiziert. Er trainiert sich jetzt über `JFastText.runCmd` ein winziges echtes Modell und läuft damit zum ersten Mal durch — und legte dabei offen:

**`DocumentClass.probability` bekam `predictProba`s `logProb`**, also einen Wert ≤ 0. Dass der alte Test `isBetween(0.0, 1.0)` zusicherte, zeigt die Absicht — sie lief nur nie. Jetzt `exp(logProb)`.

**`DocumentClass.category` trug fastTexts Ablageformat.** Konsumenten hätten `__label__sport` statt `sport` gesehen.

## Test

10 Tests, alle grün. Sechs davon halten das Cache-Verhalten fest, zwei unter echter Nebenläufigkeit: dass bei 32 gleichzeitigen Erstzugriffen genau einmal geladen wird, und dass nie zwei Blöcke gleichzeitig auf derselben Instanz laufen. Ein weiterer prüft, dass zwei verschiedene Modelle sich nicht gegenseitig blockieren.

`./gradlew :packages:document-classifier:test` → BUILD SUCCESSFUL.

## Nicht enthalten

`MAX_PREDICTIONS = 3` bleibt fest verdrahtet. Top-k ist eine Rangfolge, keine Mehrfachzuordnung — für „mehrere Kategorien treffen zu" braucht es fastText mit `-loss ova` und einen Schwellenwert statt Top-k. Das hängt an der noch offenen Entscheidung über die Kategorien-Taxonomie und gehört in einen eigenen Vorgang.

Der Klassifikator ist weiterhin in `server-core` nicht verdrahtet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012R7ftJk7MMA6VBavM8sxrP
