### PR TITLE
fix(frontend): build the oauth login url from the active product

### DIFF
--- a/packages/frontend/libs/components/src/lib/pages/login/login.page.spec.ts
+++ b/packages/frontend/libs/components/src/lib/pages/login/login.page.spec.ts
@@ -9,12 +9,17 @@ import {
 import { RouterTestingModule } from '@angular/router/testing';
 import { ServerConfigService } from '../../services/server-config.service';
 import { ApolloClient } from '@apollo/client/core';
+import { environment } from '@feedless/core';
+import { GqlVertical } from '@feedless/graphql-api';
+
+// isDevMode() reads this global; production builds compile it to false
+const angularGlobals = globalThis as { ngDevMode?: unknown };
 
 describe('LoginPage', () => {
   let component: LoginPage;
   let fixture: ComponentFixture<LoginPage>;
 
-  beforeEach(async () => {
+  async function createPage() {
     await TestBed.configureTestingModule({
       imports: [
         LoginPage,
@@ -30,9 +35,29 @@ describe('LoginPage', () => {
     );
     component = fixture.componentInstance;
     fixture.detectChanges();
+  }
+
+  const initialDevMode = angularGlobals.ngDevMode;
+  const initialProduct = environment.product;
+
+  afterEach(() => {
+    angularGlobals.ngDevMode = initialDevMode;
+    environment.product = initialProduct;
   });
 
-  it('should create', () => {
+  it('should create', async () => {
+    await createPage();
+
     expect(component).toBeTruthy();
+  });
+
+  it('logs in with the oauth registration of the active product outside dev mode', async () => {
+    angularGlobals.ngDevMode = false;
+    environment.product = GqlVertical.Upcoming;
+
+    await createPage();
+
+    const apiUrl = TestBed.inject(ServerConfigService).apiUrl;
+    expect(component.loginUrl).toBe(`${apiUrl}/oauth2/authorization/upcoming`);
   });
 });

--- a/packages/frontend/libs/components/src/lib/pages/login/login.page.ts
+++ b/packages/frontend/libs/components/src/lib/pages/login/login.page.ts
@@ -7,11 +7,7 @@ import {
   OnDestroy,
   OnInit,
 } from '@angular/core';
-import {
-  AppConfigService,
-  AuthService,
-  ServerConfigService,
-} from '../../services';
+import { AuthService, ServerConfigService } from '../../services';
 import { ActivatedRoute, Router } from '@angular/router';
 import { debounce, interval, Subscription } from 'rxjs';
 import { addIcons } from 'ionicons';
@@ -32,6 +28,7 @@ import {
 import { FormsModule } from '@angular/forms';
 import { EmailLoginComponent } from '../../components/email-login/email-login.component';
 import { GqlAuthType, GqlProfileName } from '@feedless/graphql-api';
+import { environment } from '@feedless/core';
 
 @Component({
   selector: 'app-login-page',
@@ -58,7 +55,6 @@ export class LoginPage implements OnInit, OnDestroy {
   protected readonly serverConfig = inject(ServerConfigService);
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly router = inject(Router);
-  private readonly appConfig = inject(AppConfigService);
   private readonly changeRef = inject(ChangeDetectorRef);
   private readonly authService = inject(AuthService);
 
@@ -78,7 +74,7 @@ export class LoginPage implements OnInit, OnDestroy {
     if (isDevMode()) {
       this.loginUrl = serverConfig.apiUrl + '/oauth2/authorization/github';
     } else {
-      this.loginUrl = `${serverConfig.apiUrl}/oauth2/authorization/${this.appConfig.activeProductConfig.id}`;
+      this.loginUrl = `${serverConfig.apiUrl}/oauth2/authorization/${environment.product}`;
     }
     addIcons({ logoGithub });
   }


### PR DESCRIPTION
## Summary

Clicking the avatar on lokale.events (upcoming) opened the login page, which crashed in production with `TypeError: Cannot read properties of undefined (reading 'id')`. The page built the OAuth URL from `AppConfigService.activeProductConfig.id`, but the frontend copy of `AppConfigService` never assigns `activeProductConfig` (the assignment is commented out since the port from `app-web`). Dev mode never hit that branch because it hard-codes the `github` registration.

## Changes

- `LoginPage` builds the OAuth URL from `environment.product`, which `activateUserInterface` sets from `config.json` (`upcoming`) and which matches the server's `SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_UPCOMING_*` registration.
- Drops the now unused `AppConfigService` injection from `LoginPage`.
- New spec renders the page in production mode (toggles the global `ngDevMode` that `isDevMode()` reads) and asserts the URL `…/oauth2/authorization/upcoming`. Before the fix it fails with the exact production error.

## Notes

- `feed-reader` and `auction-alert` would need their own OAuth client registration on the server (named after their `product`) before their login works outside dev mode; today only `upcoming`, `feedless` and `untold` exist.

## Test plan

- [x] `nx run-many -t test` in `packages/frontend`: all 5 projects green
- [x] `nx run-many -t lint` in `packages/frontend`: 0 errors (the one warning in `login.page.ts` predates this change)
- [ ] After deploy: click the avatar on https://lokale.events and confirm the redirect to `/oauth2/authorization/upcoming`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wt7dK7qh273sw2ShtsxCQc
