### PR TITLE
fix(domain): resolve user capabilities to a UserId in the test

### DIFF
--- a/packages/domain/src/test/kotlin/org/migor/feedless/capability/UserCapabilityTest.kt
+++ b/packages/domain/src/test/kotlin/org/migor/feedless/capability/UserCapabilityTest.kt
@@ -13,13 +13,13 @@ class UserCapabilityTest {
     val userId = UserId()
     val userCapability = UserCapability(userId)
 
-    val jsonString = toJson(userCapability)
+    // JwtTokenIssuer stores only the capability payload, the UserId
+    val jsonString = toJson(userCapability.capabilityPayload)
     val capability = UnresolvedCapability(UserCapability.ID, jsonString)
 
     val actual = UserCapability.resolve(capability)
 
-    assertEquals(userId.uuid, actual.userId.uuid)
-    assertEquals(UserCapability.ID.value, actual.capabilityId.value)
+    assertEquals(userId, actual)
   }
 
   @Test


### PR DESCRIPTION
## Summary

`./gradlew lint test` has failed on every `develop` build (none green in the last 40 runs) because `UserCapabilityTest` no longer compiles: `785b7917` changed `UserCapability.resolve()` to return the `UserId`, but the first test still reads `actual.userId` and `actual.capabilityId`. Gradle stops at `:packages:domain:compileTestKotlin`, so no module after it was ever tested in CI.

## Changes

- The test serialises only the capability payload (the `UserId`), exactly like `JwtTokenIssuer.toAuthorities`, and asserts that `resolve()` returns that `UserId`.
- Production code is unchanged: all 8 callers in `server-core` already use the `UserId` return type.

## Notes

- With `domain` compiling again, the next failure is `FastTextDocumentClassifierTest` (`Model file doesn't exist!`, it passes a made-up model path). That is fixed by the still open #81, so this PR stays red until #81 is merged too. After both, the local gate is green.

## Test plan

- [x] `./gradlew lint test --continue` locally: every test and lint task green except `:packages:document-classifier:test` (fixed by #81), including `domain`, `server-core` and `frontend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wt7dK7qh273sw2ShtsxCQc
