### PR TITLE
fix(document-classifier): return real probabilities and test against a trained model

### DIFF
--- a/packages/document-classifier/src/main/kotlin/org/migor/feedless/classifier/FastTextDocumentClassifier.kt
+++ b/packages/document-classifier/src/main/kotlin/org/migor/feedless/classifier/FastTextDocumentClassifier.kt
@@ -6,6 +6,7 @@ import org.migor.feedless.document.DocumentClass
 import org.migor.feedless.document.DocumentClassifier
 import org.migor.feedless.document.DocumentClassifierModel
 import org.slf4j.LoggerFactory
+import kotlin.math.exp
 
 
 class FastTextDocumentClassifier : DocumentClassifier {
@@ -17,6 +18,6 @@ class FastTextDocumentClassifier : DocumentClassifier {
     ft.loadModel(model.model)
 
     val text = "${document.title} ${document.text}"
-    return ft.predictProba(text, 3).map { DocumentClass(it.label, it.logProb.toDouble()) }
+    return ft.predictProba(text, 3).map { DocumentClass(it.label, exp(it.logProb.toDouble())) }
   }
 }

--- a/packages/document-classifier/src/test/kotlin/org/migor/feedless/classifier/FastTextDocumentClassifierTest.kt
+++ b/packages/document-classifier/src/test/kotlin/org/migor/feedless/classifier/FastTextDocumentClassifierTest.kt
@@ -1,22 +1,28 @@
 package org.migor.feedless.classifier
 
+import com.github.jfasttext.JFastText
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import org.migor.feedless.document.Document
 import org.migor.feedless.document.DocumentClassifierModel
 import org.migor.feedless.document.ReleaseStatus
 import org.migor.feedless.repository.RepositoryId
+import java.nio.file.Path
 import java.util.*
+import kotlin.io.path.writeLines
 
 class FastTextDocumentClassifierTest {
 
   private lateinit var classifier: FastTextDocumentClassifier
+  private lateinit var model: DocumentClassifierModel
 
   @BeforeEach
-  fun setUp() {
+  fun setUp(@TempDir tempDir: Path) {
     classifier = FastTextDocumentClassifier()
+    model = DocumentClassifierModel(trainModel(tempDir))
   }
 
   @Test
@@ -30,11 +36,32 @@ class FastTextDocumentClassifierTest {
       contentHash = UUID.randomUUID().toString()
     )
 
-    val results = classifier.classify(document, DocumentClassifierModel("test"))
+    val results = classifier.classify(document, model)
 
     assertThat(results).isNotEmpty()
-    assertThat(results.first().category).isNotEmpty()
-    assertThat(results.first().probability).isBetween(0.0, 1.0)
+    assertThat(results.first().category).isEqualTo("__label__tech")
+    assertThat(results).allSatisfy { assertThat(it.probability).isBetween(0.0, 1.0) }
   }
 
+  private fun trainModel(dir: Path): String {
+    val trainingData = dir.resolve("train.txt")
+    trainingData.writeLines(
+      listOf(
+        "__label__tech new laptop chip performance battery speed review",
+        "__label__tech the processor delivers amazing speed and battery life",
+        "__label__tech macbook pro review with the fastest chip",
+        "__label__sports the team won the football match in the final minute",
+        "__label__sports the striker scored two goals in the league game",
+        "__label__sports tennis player wins the championship final",
+      )
+    )
+    val output = dir.resolve("model").toString()
+    JFastText().runCmd(
+      arrayOf(
+        "supervised", "-input", trainingData.toString(), "-output", output,
+        "-epoch", "50", "-minCount", "1", "-thread", "1", "-verbose", "0"
+      )
+    )
+    return "$output.bin"
+  }
 }


### PR DESCRIPTION
## Summary

`FastTextDocumentClassifierTest` has failed on every run since it was written, which is what keeps CI on `develop` red (the last 5 runs failed on `:packages:document-classifier:test`). Fixing the test exposed a real bug: the classifier returned log probabilities as `probability`.

## Changes

- **Test:** the test passed the literal string `"test"` as the model path, a file that never existed, so `loadModel` threw `Model file doesn't exist!`. It now trains a tiny fastText model (6 labelled sentences, `-thread 1` for determinism) into a `@TempDir`, then asserts the top label is `__label__tech` and every probability is within `[0, 1]`.
- **Classifier:** `JFastText.ProbLabel.logProb` is a log probability (≤ 0) and was stored unchanged in `DocumentClass.probability`, so a document came back with about −0.69 instead of about 0.5. It's now converted with `exp()`.

## Test plan

- [x] New test fails on the probability assertion before the classifier fix, passes after
- [x] `./gradlew test --continue` from the repo root: `BUILD SUCCESSFUL`, no failed tasks (`server-core`: 453 tests, 0 failures, 34 skipped)
- [ ] CI green on this PR

## Not in scope

`FastTextDocumentClassifier` creates and loads a new `JFastText` per `classify` call and never calls `unloadModel()`, so native memory leaks. Nothing wires the classifier in yet, so it's left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011FqUfzjdjiJ37125RxTSaL
