### PR TITLE
fix(domain): allow users without a last login

### DIFF
--- a/packages/domain/src/main/kotlin/org/migor/feedless/user/User.kt
+++ b/packages/domain/src/main/kotlin/org/migor/feedless/user/User.kt
@@ -13,7 +13,7 @@ data class User(
   val validatedEmailAt: LocalDateTime? = null,
   val admin: Boolean = false,
   val anonymous: Boolean = false,
-  val lastLogin: LocalDateTime,
+  val lastLogin: LocalDateTime? = null,
   val karma: Int = 0,
   val spammingSubmissions: Boolean = false,
   val spammingVotes: Boolean = false,

--- a/packages/jpa-data/src/main/kotlin/org/migor/feedless/data/jpa/user/UserEntity.kt
+++ b/packages/jpa-data/src/main/kotlin/org/migor/feedless/data/jpa/user/UserEntity.kt
@@ -70,7 +70,7 @@ open class UserEntity : EntityWithUUID() {
   open var anonymous: Boolean = false
 
   @Column(name = "last_login")
-  open var lastLogin: LocalDateTime = LocalDateTime.now()
+  open var lastLogin: LocalDateTime? = null
 
   @Column(nullable = false, name = "karma")
   open var karma: Int = 0

--- a/packages/jpa-data/src/test/kotlin/org/migor/feedless/data/jpa/user/UserMapperTest.kt
+++ b/packages/jpa-data/src/test/kotlin/org/migor/feedless/data/jpa/user/UserMapperTest.kt
@@ -1,0 +1,19 @@
+package org.migor.feedless.data.jpa.user
+
+import kotlin.test.Test
+import kotlin.test.assertNull
+
+class UserMapperTest {
+
+  @Test
+  fun `maps a user without last login`() {
+    val entity = UserEntity().apply {
+      email = "legacy@example.org"
+      lastLogin = null
+    }
+
+    val user = entity.toDomain()
+
+    assertNull(user.lastLogin)
+  }
+}


### PR DESCRIPTION
## Problem

The GitHub OAuth callback (`/login/oauth2/code/github`) fails for existing users whose `t_user.last_login` is `NULL`:

```
java.lang.NullPointerException: Parameter specified as non-null is null: method org.migor.feedless.user.User.<init>, parameter lastLogin
  at org.migor.feedless.data.jpa.user.UserMapperImpl.toDomain(UserMapperImpl.java:78)
  at org.migor.feedless.data.jpa.user.UserJpaRepository.findByGithubId(UserJpaRepository.kt:32)
  at org.migor.feedless.config.SecurityConfig$resolveUserByGithubId$2.invokeSuspend(SecurityConfig.kt:260)
```

`V23__name_foreign_keys.sql` dropped the `NOT NULL` on `last_login`, but `User.lastLogin` and `UserEntity.lastLogin` stayed non-null. The entity's `= LocalDateTime.now()` default hid that, because Hibernate still sets `null` when it loads a row, so the error only showed up in the mapper.

## Change

- `User.lastLogin` is now `LocalDateTime? = null`, which matches the schema.
- `UserEntity.lastLogin` is now `LocalDateTime? = null`. Every code path that creates a user still sets it explicitly.
- New `UserMapperTest` maps a user with no last login.

No migration. Existing `NULL` rows are fixed by hand on prod.

## Verification

- Without the fix, `UserMapperTest` fails with the same NPE as prod.
- With the fix, `:packages:jpa-data:test`, `:packages:domain:test` and `:packages:server-core:compileTestKotlin` pass.
- The full `./gradlew lint test` was not run locally. CI covers it.

Note: `.gitignore` has a bare `data` rule, which also matches `packages/jpa-data/src/**/data/`. New files there have to be added with `git add -f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GjFrhNgiZbSyCZN5A7kpw
