### PR TITLE
fix(server-core): index document source_id and source repository_id

### DIFF
--- a/packages/jpa-data/src/main/kotlin/org/migor/feedless/data/jpa/document/DocumentEntity.kt
+++ b/packages/jpa-data/src/main/kotlin/org/migor/feedless/data/jpa/document/DocumentEntity.kt
@@ -45,6 +45,7 @@ import java.util.*
     Index(name = "document_published_at_idx", columnList = StandardJpaFields.publishedAt),
     Index(name = "document_starting_at_idx", columnList = StandardJpaFields.startingAt),
     Index(name = "document_created_at_idx", columnList = StandardJpaFields.createdAt),
+    Index(name = "document_source_id_idx", columnList = StandardJpaFields.sourceId),
   ]
 )
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)

--- a/packages/jpa-data/src/main/kotlin/org/migor/feedless/data/jpa/source/SourceEntity.kt
+++ b/packages/jpa-data/src/main/kotlin/org/migor/feedless/data/jpa/source/SourceEntity.kt
@@ -32,6 +32,7 @@ import java.util.*
   name = "t_source",
   indexes = [
     Index(name = "source_created_at_idx", columnList = StandardJpaFields.createdAt),
+    Index(name = "source_repository_id_idx", columnList = StandardJpaFields.repositoryId),
   ]
 )
 open class SourceEntity : EntityWithUUID() {

--- a/packages/server-core/src/main/resources/application-database.yaml
+++ b/packages/server-core/src/main/resources/application-database.yaml
@@ -40,7 +40,7 @@ spring:
     enabled: true
     baseline-on-migrate: true
     baseline-version: 1
-    target: 85
+    target: 86
 
 hibernate:
   cache:

--- a/packages/server-core/src/main/resources/db/migration/V86__index_document_source_id.sql
+++ b/packages/server-core/src/main/resources/db/migration/V86__index_document_source_id.sql
@@ -1,0 +1,6 @@
+-- count per source seq-scanned t_document; FKs are not indexed automatically
+CREATE INDEX IF NOT EXISTS document_source_id_idx
+  ON t_document (source_id);
+
+CREATE INDEX IF NOT EXISTS source_repository_id_idx
+  ON t_source (repository_id);


### PR DESCRIPTION
## Problem

The `repositoryById` query took ~50 s for a repository with 226 sources. Every `Source.recordCount` resolves to `SELECT count(*) FROM t_document WHERE source_id = ?`, and `t_document.source_id` has no index: V47 added the column with a foreign key, but Postgres does not index foreign keys automatically. With a source page of 10, one request ran 10 sequential scans over the whole `t_document` table, across all repositories.

`t_source.repository_id` is also unindexed, so `sourcesCount`, `sourcesCountWithProblems` and the source listing scan `t_source`. It is a smaller table, but the same kind of fix.

## Change

- `V86__index_document_source_id.sql` adds `document_source_id_idx` on `t_document (source_id)` and `source_repository_id_idx` on `t_source (repository_id)`.
- Bumps `spring.flyway.target` from 85 to 86 in `application-database.yaml`. Without this, V86 is never applied.
- Adds the same indexes to the `@Table` declarations of `DocumentEntity` and `SourceEntity`, so the entities match the schema.

## Notes for review

- **Plain `CREATE INDEX`, not `CONCURRENTLY`.** Flyway 9.22 takes a transactional advisory lock on PostgreSQL by default, and `CREATE INDEX CONCURRENTLY` waits on that lock and hangs. The plain index blocks writes to `t_document` (reads still work) while it builds during startup. If production's `t_document` is large enough for that to matter, the index can be created by hand with `CONCURRENTLY` before deploying; `IF NOT EXISTS` makes the migration a no-op then.
- **Tests apply the migration.** The Testcontainers IntTests (`PostgreSQLExtension`, `database` profile) run Flyway, and their target comes from `application-database.yaml`. With the bump, all five apply V86 and end at v86. `./gradlew lint test` passes.
- **Query plans.** I ran the migration SQL against a local PostGIS at V85 inside a rolled-back transaction: `EXPLAIN` on both count queries switches from `Seq Scan` to `Bitmap Index Scan` on the new indexes.
- **Not measured on production data.** To confirm the speed-up, run `EXPLAIN (ANALYZE, BUFFERS) SELECT count(*) FROM t_document WHERE source_id = '<id>'` before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3Lyx4kfBpFoQWjrMD4uTt
