### PR TITLE
fix(k8s): gate core traffic on readiness and survive long migrations

### DIFF
--- a/k8s/feedless/feedless-core.yaml
+++ b/k8s/feedless/feedless-core.yaml
@@ -10,6 +10,12 @@ metadata:
     app.kubernetes.io/part-of: feedless
 spec:
   replicas: 1
+  # keep the old pod serving until the new one is ready
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: feedless-core
@@ -208,14 +214,30 @@ spec:
             - name: feedless-cert-volume
               mountPath: /usr/feedless/feedless.pem
               subPath: feedless.pem
-      #          livenessProbe:
-      #            httpGet:
-      #              path: /actuator/health
-      #              port: 8080
-      #            initialDelaySeconds: 20
-      #            periodSeconds: 20
-      #            timeoutSeconds: 6
-      #            failureThreshold: 4
+          # boot incl. Flyway migrations gets up to 60 min before liveness takes over
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 360
+          # no traffic while the app or its database is unhealthy; never restarts the pod
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          # JVM state only, so an external outage cannot trigger restarts
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            periodSeconds: 20
+            timeoutSeconds: 6
+            failureThreshold: 4
       volumes:
         - name: feedless-cert-volume
           secret:

--- a/packages/server-core/src/main/kotlin/org/migor/feedless/config/SecurityConfig.kt
+++ b/packages/server-core/src/main/kotlin/org/migor/feedless/config/SecurityConfig.kt
@@ -137,6 +137,8 @@ class SecurityConfig {
     val urls = mutableListOf(
       "/graphql",
       "/actuator/health",
+      "/actuator/health/liveness",
+      "/actuator/health/readiness",
       "/subscriptions",
       ApiUrls.transformFeed,
       ApiUrls.webToFeed,

--- a/packages/server-core/src/test/kotlin/org/migor/feedless/config/SecurityConfigIntTest.kt
+++ b/packages/server-core/src/test/kotlin/org/migor/feedless/config/SecurityConfigIntTest.kt
@@ -115,6 +115,21 @@ class SecurityConfigIntTest {
     assertThat(HttpStatus.FORBIDDEN).isNotEqualTo(response.statusCode)
   }
 
+  // kubelet probes carry no credentials
+  @ParameterizedTest
+  @CsvSource(
+    value = [
+      "health",
+      "health/liveness",
+      "health/readiness",
+    ]
+  )
+  fun whenProbingHealthWithoutAuth_ThenSuccess(path: String) {
+    val restTemplate = TestRestTemplate()
+    val response = restTemplate.getForEntity("$actuatorEndpoint/$path", String::class.java)
+    assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+  }
+
 //  @ParameterizedTest
 //  @CsvSource(value = [
 ////    "bucket/$feedId",


### PR DESCRIPTION
## Summary

`api.lokale.events` served `502 Bad Gateway` (no CORS headers, so browsers reported CORS errors) while the core ran the V86 migration, a non-concurrent `CREATE INDEX` on `t_document`. Spring does not listen on 8080 until Flyway finishes, and the Deployment had no readiness probe, so Traefik routed to a pod that was still booting. This adds startup, readiness and liveness probes so a long migration no longer takes the API down or gets the pod killed.

## Changes

- `startupProbe` on `/actuator/health` with a 60 min budget (10s × 360) for boot plus migrations; liveness and readiness only start after it succeeds.
- `readinessProbe` on `/actuator/health` keeps the pod out of the Service until it actually serves; explicit `maxSurge: 1, maxUnavailable: 0` keeps the old pod serving during the rollout.
- `livenessProbe` is back, now on `/actuator/health/liveness` (JVM state only), so a DB or mail outage can no longer cause restart loops like the one fixed in 771160594.
- `SecurityConfig` whitelists `/actuator/health/liveness` and `/actuator/health/readiness`; kubelet probes carry no credentials and got 401. Details stay hidden (`show-details: when-authorized`).

## Rollout order

1. Merge and deploy the new image **first**: the current image answers 401 on `/actuator/health/liveness`, so the liveness probe would fail and restart the pod.
2. Then `kubectl apply -f k8s/feedless/feedless-core.yaml`.

## Known trade-offs

- During a long non-concurrent migration the old pod keeps serving reads, but writes to the indexed table block until the index is built.
- Old and new pods both run schedulers for the length of the migration; no scheduler lock (e.g. ShedLock) exists.

## Test plan

- [x] New `SecurityConfigIntTest` case: `health`, `health/liveness`, `health/readiness` return 200 without auth (failed with 401 on the two sub-paths before the fix)
- [x] `./gradlew lint test` passes (80 server-core suites, 0 failures)
- [x] Manifest parses; probes and strategy sit on the right objects
- [ ] After deploy: `kubectl get pod -l app=feedless-core` shows the new pod Ready only after boot, and RESTARTS stays at 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tjsgh5QHbtaccb6SikC39B
