### PR TITLE
feat(k8s): route outgoing mail into a basic-auth mailpit catch-all

### DIFF
--- a/k8s/feedless/feedless-config.yaml
+++ b/k8s/feedless/feedless-config.yaml
@@ -25,7 +25,8 @@ metadata:
 data:
   APP_PRERENDER_TIMEOUT_MILLIS: "10000"
   APP_DATABASE_URL: "jdbc:postgresql://postgis.default.svc.cluster.local:5432/feedless?ssl=false"
-  APP_ACTIVE_PROFILES: "saas,api"
+  # `mailpit` sends all mail to the catch-all in k8s/mailpit.yaml; remove it to use a real provider
+  APP_ACTIVE_PROFILES: "saas,api,mailpit"
   APP_PEM_FILE: "/usr/feedless/feedless.pem"
   APP_WHITELISTED_HOSTS: "feedless-core.default.svc.cluster.local,172.26.0.1"
   AUTH_TOKEN_ANONYMOUS_VALIDFORDAYS: "3"

--- a/k8s/mailpit-ingress.yaml
+++ b/k8s/mailpit-ingress.yaml
@@ -1,0 +1,43 @@
+# Basic auth for mailpit.feedless.org.
+#
+# The credentials are not committed. Create the secret once before applying:
+#   kubectl create secret generic mailpit-basic-auth \
+#     --type=kubernetes.io/basic-auth \
+#     --from-literal=username=<user> --from-literal=password=<password>
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: mailpit-basic-auth
+  # Must match the `default-` prefix in the router.middlewares annotation below.
+  namespace: default
+spec:
+  basicAuth:
+    secret: mailpit-basic-auth
+    realm: "Authentication Required"
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mailpit-ingress
+  annotations:
+    app.kubernetes.io/name: mailpit-ingress
+    cert-manager.io/cluster-issuer: letsencrypt
+    # HTTP -> HTTPS is handled cluster-wide by ports.web.redirectTo in traefik.yaml.
+    traefik.ingress.kubernetes.io/router.middlewares: default-mailpit-basic-auth@kubernetescrd
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - mailpit.feedless.org
+      secretName: feedless-org-tls
+  rules:
+    - host: mailpit.feedless.org
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mailpit
+                port:
+                  number: 8025

--- a/k8s/mailpit.yaml
+++ b/k8s/mailpit.yaml
@@ -1,0 +1,104 @@
+# Catch-all SMTP sink for feedless-core, active with the `mailpit` Spring profile.
+# SMTP stays cluster-internal; the web UI is exposed behind basic auth in mailpit-ingress.yaml.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: mailpit-pv
+  labels:
+    type: local
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: manual
+  hostPath:
+    path: /opt/feedless/data/mailpit
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mailpit-pvc
+spec:
+  storageClassName: manual
+  volumeName: mailpit-pv
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mailpit
+  labels:
+    app: mailpit
+spec:
+  replicas: 1
+  # single SQLite file on a RWO volume, so never run two pods at once
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: mailpit
+  template:
+    metadata:
+      labels:
+        app: mailpit
+    spec:
+      containers:
+        - name: mailpit
+          image: axllent/mailpit:v1.31.1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8025
+            - name: smtp
+              containerPort: 1025
+          env:
+            - name: MP_DATABASE
+              value: /data/mailpit.db
+            - name: MP_MAX_MESSAGES
+              value: "5000"
+          volumeMounts:
+            - name: mailpit-data
+              mountPath: /data
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: http
+            periodSeconds: 20
+      volumes:
+        - name: mailpit-data
+          persistentVolumeClaim:
+            claimName: mailpit-pvc
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: mailpit
+spec:
+  selector:
+    app: mailpit
+  ports:
+    - name: http
+      port: 8025
+      targetPort: http
+      protocol: TCP
+    - name: smtp
+      port: 1025
+      targetPort: smtp
+      protocol: TCP

--- a/packages/server-core/src/main/resources/application-mailpit.yaml
+++ b/packages/server-core/src/main/resources/application-mailpit.yaml
@@ -1,0 +1,16 @@
+# Routes every outgoing mail into the in-cluster mailpit catch-all (k8s/mailpit.yaml).
+# Append `mailpit` to APP_ACTIVE_PROFILES; it must come after `saas` so it wins over
+# application-mail.yaml. Drop it and set APP_MAIL_* to switch to a real provider.
+spring:
+  mail:
+    host: mailpit.default.svc.cluster.local
+    port: 1025
+    username: ""
+    password: ""
+    test-connection: false
+    properties:
+      mail:
+        smtp:
+          auth: false
+          starttls:
+            enable: false

--- a/packages/server-core/src/test/kotlin/org/migor/feedless/mail/MailPropertiesTest.kt
+++ b/packages/server-core/src/test/kotlin/org/migor/feedless/mail/MailPropertiesTest.kt
@@ -25,7 +25,7 @@ class MailPropertiesTest {
     // spring.mail.test-connection=true makes MailSenderValidatorAutoConfiguration
     // connect in its constructor, so an unreachable mail server aborts the
     // context refresh and takes the whole API down.
-    listOf("application-mail.yaml", "application-prod.yaml").forEach { file ->
+    listOf("application-mail.yaml", "application-prod.yaml", "application-mailpit.yaml").forEach { file ->
       val value = at(load(file), "spring", "mail", "test-connection")
       assertThat(value)
         .describedAs("spring.mail.test-connection in %s must not default to true", file)
@@ -54,6 +54,14 @@ class MailPropertiesTest {
     assertThat(value)
       .describedAs("management.health.mail.enabled must stay off")
       .isEqualTo(false)
+  }
+
+  @Test
+  fun `mailpit profile targets the in-cluster catch-all without auth`() {
+    val mailpit = load("application-mailpit.yaml")
+    assertThat(at(mailpit, "spring", "mail", "host")).isEqualTo("mailpit.default.svc.cluster.local")
+    assertThat(at(mailpit, "spring", "mail", "port")).isEqualTo(1025)
+    assertThat(at(mailpit, "spring", "mail", "properties", "mail", "smtp", "auth")).isEqualTo(false)
   }
 
   @Test


### PR DESCRIPTION
## Summary
Runs all outgoing mail from feedless-core into an in-cluster Mailpit catch-all before a real mail provider is wired up. The Mailpit web UI is protected by basic auth; SMTP never leaves the cluster.

## Changes
- `k8s/mailpit.yaml`: Mailpit Deployment (`axllent/mailpit:v1.31.1`, `Recreate`, `/readyz` and `/livez` probes), a Service for UI (8025) and SMTP (1025), and a 1Gi hostPath PV/PVC at `/opt/feedless/data/mailpit`, following the postgis pattern.
- `k8s/mailpit-ingress.yaml`: Ingress for `mailpit.feedless.org` behind a Traefik `basicAuth` Middleware, the same setup as Plausible.
- `application-mailpit.yaml`: new Spring profile pointing `spring.mail` at `mailpit.default.svc.cluster.local:1025` with no auth and no STARTTLS.
- `feedless-config.yaml`: `APP_ACTIVE_PROFILES` becomes `saas,api,mailpit`. The entrypoint puts it after `saas`, so it overrides `application-mail.yaml`. To switch to a real provider, remove `mailpit` and set `APP_MAIL_*`.
- `MailPropertiesTest`: covers the new profile (target host, port, no auth, `test-connection` never true).

## Before applying
The basic-auth credentials are not committed. Create the secret once:

```
kubectl create secret generic mailpit-basic-auth --type=kubernetes.io/basic-auth \
  --from-literal=username=<user> --from-literal=password=<password>
```

`mailpit.feedless.org` also needs a DNS record.

## Test plan
- [x] `MailPropertiesTest` passes (5/5)
- [x] Manifests parse as valid YAML
- [ ] `kubectl apply --dry-run=server` against the cluster
- [ ] After deploy: trigger a mail (e.g. a login code) and see it in the Mailpit UI; the UI asks for basic auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCaqdjVuPF1aeqaQYPrpfM
