### PR TITLE
fix(server-core): index t_document foreign-key columns

### DIFF
--- a/packages/server-core/src/main/resources/application-database.yaml
+++ b/packages/server-core/src/main/resources/application-database.yaml
@@ -40,7 +40,7 @@ spring:
     enabled: true
     baseline-on-migrate: true
     baseline-version: 1
-    target: 86
+    target: 87
 
 hibernate:
   cache:

--- a/packages/server-core/src/main/resources/db/migration/V87__index_document_fk_columns.sql
+++ b/packages/server-core/src/main/resources/db/migration/V87__index_document_fk_columns.sql
@@ -1,0 +1,15 @@
+-- deleting a document seq-scanned every referencing table per row; FKs are not indexed automatically
+CREATE INDEX IF NOT EXISTS document_parent_id_idx
+  ON t_document (parent_id) WHERE parent_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS pipeline_job_document_id_idx
+  ON t_pipeline_job (document_id) WHERE document_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS attachment_document_id_idx
+  ON t_attachment (document_id);
+
+CREATE INDEX IF NOT EXISTS annotation_document_id_idx
+  ON t_annotation (document_id) WHERE document_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS annotation_text_comment_id_idx
+  ON t_annotation_text (comment_id);


### PR DESCRIPTION
## Summary

Deleting from `t_document` runs the `ON DELETE` action of every foreign key that references it. None of the referencing columns had an index, so every deleted row triggered a sequential scan of `t_document` (self-referencing `parent_id`) and of each child table. On a 30M-row `t_document`, the capacity retention delete (`DocumentDAO.deleteAllByRepositoryIdAndStatusWithSkip`) ran for over 12 hours, and the V86 migration waited behind it for almost 4 hours.

## Changes

- `V87__index_document_fk_columns.sql` indexes all five FK columns that reference `t_document`. The list matches a catalog query (`pg_constraint` where `confrelid = 't_document'`) run against production:
  - `t_document.parent_id` (CASCADE), partial `WHERE parent_id IS NOT NULL`. No code writes `parent_id`, so the index stays small.
  - `t_pipeline_job.document_id` (CASCADE), partial `WHERE document_id IS NOT NULL`
  - `t_attachment.document_id` (CASCADE)
  - `t_annotation.document_id` (SET NULL), partial `WHERE document_id IS NOT NULL`
  - `t_annotation_text.comment_id` (CASCADE)
- `application-database.yaml`: Flyway `target: 86` → `87`. Without this bump Flyway silently skips V87.

## Deploying

A plain `CREATE INDEX` blocks writes to the table while it builds. On a large `t_document`, create the indexes by hand first, with `CREATE INDEX CONCURRENTLY` while the app is up or a plain `CREATE INDEX` while it is down. Use the same names and definitions as the migration. Its `IF NOT EXISTS` then makes V87 a no-op at startup.

## Test plan

- [x] `DocumentIntTest` on a fresh PostGIS container: Flyway reports `Migrating schema "public" to version "87 - index document fk columns"` and `now at version v87`
- [x] `./gradlew :packages:server-core:test` passes
- [ ] After deploy: `EXPLAIN (ANALYZE)` of a single-document delete shows index lookups in the `Trigger for constraint …` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jg2ENPSs8Js9Nv4Ha7P2jp
