### PR TITLE
fix(k8s): run feedless-agent with two replicas

### DIFF
--- a/k8s/feedless/feedless-agent.yaml
+++ b/k8s/feedless/feedless-agent.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: feedless-agent
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: feedless-agent


### PR DESCRIPTION
## Problem

`k8s/feedless/feedless-agent.yaml` should run the agent with 2 replicas, as it does on `master`. On `develop` it is 1. Commit `3705e0f95` (`fix(frontend) ion-router -> angular-router`, 2026-02-23) changed it from 2 to 1 alongside unrelated frontend changes, which looks accidental. That commit is not on `master` yet, so the next release would scale production down to a single agent.

## Change

Sets `replicas: 2` on the `feedless-agent` Deployment, matching `master`.

## Notes for review

- Nothing under `k8s/` defines an autoscaler, so the manifest value is the replica count that runs.
- I didn't check the live cluster; its kubectl context isn't configured on the machine this was prepared on. After deploying, check with `kubectl get deploy feedless-agent -o jsonpath='{.spec.replicas}/{.status.readyReplicas}'`.
- `./gradlew lint test` was not run, because no Gradle task covers `k8s/`. The manifest was checked by parsing it as YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3Lyx4kfBpFoQWjrMD4uTt
