### PR TITLE
fix(server-core): index source and repository foreign-key columns

### DIFF
--- a/packages/server-core/src/main/resources/application-database.yaml
+++ b/packages/server-core/src/main/resources/application-database.yaml
@@ -40,7 +40,7 @@ spring:
     enabled: true
     baseline-on-migrate: true
     baseline-version: 1
-    target: 87
+    target: 88
 
 hibernate:
   cache:

--- a/packages/server-core/src/main/resources/db/migration/V88__index_source_repository_fk_columns.sql
+++ b/packages/server-core/src/main/resources/db/migration/V88__index_source_repository_fk_columns.sql
@@ -1,0 +1,27 @@
+-- source/repository/user deletes seq-scanned these tables per row, and hot queries filter on them
+CREATE INDEX IF NOT EXISTS pipeline_job_source_id_idx
+  ON t_pipeline_job (source_id);
+
+CREATE INDEX IF NOT EXISTS harvest_source_id_created_at_idx
+  ON t_harvest (source_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS scrape_action_source_id_idx
+  ON t_scrape_action (source_id);
+
+CREATE INDEX IF NOT EXISTS repository_owner_id_idx
+  ON t_repository (owner_id);
+
+CREATE INDEX IF NOT EXISTS repository_group_id_idx
+  ON t_repository (group_id) WHERE group_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS user_inbox_repository_id_idx
+  ON t_user (inbox_repository_id) WHERE inbox_repository_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS annotation_repository_id_idx
+  ON t_annotation (repository_id) WHERE repository_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS annotation_owner_id_idx
+  ON t_annotation (owner_id);
+
+CREATE INDEX IF NOT EXISTS segment_repository_id_idx
+  ON t_segment (repository_id);


### PR DESCRIPTION
## Summary

Follow-up to #92. I audited every foreign key in the schema (built from all migrations up to V87, then read from `pg_constraint`): 29 of 53 have no index. This PR indexes the nine that matter, meaning their parent rows get deleted routinely (each delete then scans the child table) or hot queries filter on them. Deleting a source currently runs a full scan of `t_pipeline_job`, `t_harvest` and `t_scrape_action`, the same problem #92 fixed for documents.

## Changes

`V88__index_source_repository_fk_columns.sql`:

| Index | Why |
|---|---|
| `t_pipeline_job (source_id)` | Cascades on source delete. `findAllPendingBatched` runs every ~3s; `existsBySourceIdAndUrl` runs per harvested URL. `url` is left out of the index because long URLs would exceed the btree row limit. |
| `t_harvest (source_id, created_at DESC)` | Cascades on source delete. Matches the harvest-log sort and the hourly `deleteAllTailingBySourceId`. |
| `t_scrape_action (source_id)` | Cascades on source delete. `findAllBySourceId` runs on every source update. |
| `t_repository (owner_id)` | Plan-limit checks (`countByOwnerId…`, `countAllByOwnerIdAndProduct`), `findByTitleAndOwnerId`. Cascades on user delete. |
| `t_repository (group_id)`, partial | `countByGroupId`. `SET NULL` on group delete. |
| `t_user (inbox_repository_id)`, partial | `NO ACTION` FK: every repository delete checks `t_user`. |
| `t_annotation (repository_id)`, partial | Vote counts per repository. `SET NULL` on repository delete. |
| `t_annotation (owner_id)` | Vote lookups per user. Cascades on user delete. |
| `t_segment (repository_id)` | Cascades on repository delete. |

`application-database.yaml`: Flyway `target: 87` → `88`.

The other 20 unindexed FKs are on small configuration and billing tables (`t_product`, `t_plan`, `t_order`, `t_license`, `t_invoice`, `t_feature_group`, `t_otp`, `t_user_secret`, …). Their parents are rarely deleted, so they stay as they are.

## Deploying

A plain `CREATE INDEX` blocks writes while it builds. If `t_pipeline_job` or `t_harvest` is large in production, create these by hand first with `CREATE INDEX CONCURRENTLY` and the same names and definitions. V88's `IF NOT EXISTS` then makes it a no-op.

## Test plan

- [x] `./gradlew :packages:server-core:test` passes; Flyway reports `now at version v88`
- [ ] Production check: `SELECT relname, n_live_tup, seq_scan, seq_tup_read, idx_scan FROM pg_stat_user_tables WHERE relname IN ('t_pipeline_job','t_harvest','t_scrape_action','t_repository','t_user','t_annotation','t_segment')`. `seq_tup_read` on these tables should stop growing after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jg2ENPSs8Js9Nv4Ha7P2jp
